### PR TITLE
Added command line options for verbose/quiet output, encryption, acl, etc..

### DIFF
--- a/s3_bucket_to_bucket_copy.py
+++ b/s3_bucket_to_bucket_copy.py
@@ -23,6 +23,7 @@ import logging
 import os
 import ConfigParser
 import sys
+import argparse
 
 # Log everything, and send it to stderr.
 logging.basicConfig(level=logging.WARN)
@@ -30,7 +31,7 @@ logging.basicConfig(level=logging.WARN)
 
 class Worker(threading.Thread):
     def __init__(self, queue, thread_id, aws_key, aws_secret_key,
-                 src_bucket_name, dst_bucket_name, src_path, dst_path):
+                 src_bucket_name, dst_bucket_name, src_path, dst_path, args):
         threading.Thread.__init__(self)
         self.queue = queue
         self.done_count = 0
@@ -44,9 +45,11 @@ class Worker(threading.Thread):
         self.conn = None
         self.src_bucket = None
         self.dest_bucket = None
+        self.args = args
 
     def __init_s3(self):
-        print '  t%s: conn to s3' % self.thread_id
+        if self.args.verbose:
+            print '  t%s: conn to s3' % self.thread_id
         self.conn = S3Connection(self.aws_key, self.aws_secret_key)
         self.src_bucket = self.conn.get_bucket(self.src_bucket_name)
         self.dest_bucket = self.conn.get_bucket(self.dst_bucket_name)
@@ -60,21 +63,34 @@ class Worker(threading.Thread):
                 k = self.src_bucket.get_key(key_name)
                 dist_key = self.dest_bucket.get_key(k.key)
                 if not dist_key or not dist_key.exists() or k.etag != dist_key.etag:
-                    print '  t%s: Copy: %s' % (self.thread_id, k.key)
-                    acl = self.src_bucket.get_acl(k)
-                    self.dest_bucket.copy_key(k.key, self.src_bucket_name, k.key, storage_class=k.storage_class)
-                    dist_key = self.dest_bucket.get_key(k.key)
-                    dist_key.set_acl(acl)
+                    if self.args.quiet == False:
+                        print '  t%s: Copy: %s' % (self.thread_id, k.key)
+
+                    if self.args.rr:
+                        s_class = 'REDUCED_REDUNDANCY';
+                    else:
+                        s_class = k.storage_class
+
+                    self.dest_bucket.copy_key(k.key, self.src_bucket_name, k.key, storage_class=s_class, encrypt_key=self.args.encrypt)
+
+                    if self.args.acl == False:
+                        acl = self.src_bucket.get_acl(k)
+                        dist_key = self.dest_bucket.get_key(k.key)
+                        dist_key.set_acl(acl)
                 else:
-                    print '  t%s: Exists and etag matches: %s' % (self.thread_id, k.key)
+                    if self.args.verbose:
+                        print '  t%s: Exists and etag matches: %s' % (self.thread_id, k.key)
                 self.done_count += 1
             except BaseException:
                 logging.exception('  t%s: error during copy' % self.thread_id)
             self.queue.task_done()
 
 
-def copy_bucket(aws_key, aws_secret_key, src, dst):
+def copy_bucket(aws_key, aws_secret_key, args):
     max_keys = 1000
+
+    src = args.src_bucket
+    dst = args.dest_bucket
 
     conn = S3Connection(aws_key, aws_secret_key)
     try:
@@ -91,26 +107,29 @@ def copy_bucket(aws_key, aws_secret_key, src, dst):
         raise ValueError("not currently implemented to set dest path; must use default, which will mirror the source")
     src_bucket = conn.get_bucket(src_bucket_name)
 
-    print
-    print 'Start copy of %s to %s' % (src, dst)
-    print
+    if args.verbose:
+        print
+        print 'Start copy of %s to %s' % (src, dst)
+        print
 
     result_marker = ''
     q = LifoQueue(maxsize=5000)
 
     for i in range(20):
-        print 'Adding worker thread %s for queue processing' % i
+        if args.verbose:
+            print 'Adding worker thread %s for queue processing' % i
         t = Worker(q, i, aws_key, aws_secret_key,
                    src_bucket_name, dst_bucket_name,
-                   src_path, dst_path)
+                   src_path, dst_path, args)
         t.daemon = True
         t.start()
 
     i = 0
 
     while True:
-        print 'Fetch next %s, backlog currently at %s, have done %s' % \
-            (max_keys, q.qsize(), i)
+        if args.verbose:
+            print 'Fetch next %s, backlog currently at %s, have done %s' % \
+                (max_keys, q.qsize(), i)
         try:
             keys = src_bucket.get_all_keys(max_keys=max_keys,
                                            marker=result_marker,
@@ -120,9 +139,11 @@ def copy_bucket(aws_key, aws_secret_key, src, dst):
             for k in keys:
                 i += 1
                 q.put(k.key)
-            print 'Added %s keys to queue' % len(keys)
+            if args.verbose:
+                print 'Added %s keys to queue' % len(keys)
             if len(keys) < max_keys:
-                print 'All items now in queue'
+                if args.verbose:
+                    print 'All items now in queue'
                 break
             result_marker = keys[max_keys - 1].key
             while q.qsize() > (q.maxsize - max_keys):
@@ -131,23 +152,68 @@ def copy_bucket(aws_key, aws_secret_key, src, dst):
             logging.exception('error during fetch, quitting')
             break
 
-    print 'Waiting for queue to be completed'
+    if args.verbose:
+        print 'Waiting for queue to be completed'
     q.join()
-    print
-    print 'Done'
-    print
+
+    if args.verbose:
+        print
+        print 'Done'
+        print
 
 
 if __name__ == "__main__":
 
     j = os.path.join
     config_fn = j(os.environ['HOME'], '.s3cfg')
+
+    parser = argparse.ArgumentParser(description = "s3 bucket to bucket copy")
+    parser.add_argument('-c', '--config', 
+                        help="s3 Configuration file. Defaults to ~/.s3cfg",
+                        required = False,
+                        default = config_fn)
+    parser.add_argument('-v', '--verbose',
+                        help="Verbose output",
+                        required = False,
+                        action = 'store_true',
+                        default = False)
+    parser.add_argument('-q', '--quiet',
+                        help="No output",
+                        required = False,
+                        action = 'store_true',
+                        default = False)
+    parser.add_argument('-a', '--default-acl',
+                        help = 'Skip copying ACL from src bucket and use the default ACL of the destination bucket instead',
+                        dest='acl',
+                        required = False,
+                        action = 'store_true',
+                        default = False)
+    parser.add_argument('-e', '--encrypt',
+                        help='Use server-side encryption to encrypt the file on S3',
+                        required = False,
+                        action = 'store_true',
+                        default = False)
+    parser.add_argument('-r', '--reduced-redundancy',
+                        help='Store objects in the dest bucket using the reduced redundancy storage class',
+                        dest='rr',
+                        required = False,
+                        action = 'store_true',
+                        default = False)
+    parser.add_argument('src_bucket', 
+                        help = "Source s3 bucket name and optional path")
+    parser.add_argument('dest_bucket',
+                        help = "Destination s3 bucket name")
+
+    args = parser.parse_args()
+      
     config = ConfigParser.ConfigParser()
-    if not config.read(config_fn):
-        raise EnvironmentError("You need to configure s3cmd, 's3cmd --configure'")
+    if not config.read(args.config):
+        raise EnvironmentError("%s not found. Try running 's3cmd --configure'" % (args.config))
 
     default_aws_key = config.get('default', 'access_key')
     default_aws_secret_key = config.get('default', 'secret_key')
 
-    (src_arg, dest_arg) = sys.argv[1:3]
-    copy_bucket(default_aws_key, default_aws_secret_key, src_arg, dest_arg)
+    if args.quiet:
+        args.verbose = False
+
+    copy_bucket(default_aws_key, default_aws_secret_key, args)


### PR DESCRIPTION
Added a bunch of command line parameters by incorporating argparse:

$ ./s3_bucket_to_bucket_copy.py  -h
usage: s3_bucket_to_bucket_copy.py [-h] [-c CONFIG] [-v] [-q] [-a] [-e] [-r]
                                   src_bucket dest_bucket

s3 bucket to bucket copy

positional arguments:
  src_bucket            Source s3 bucket name and optional path
  dest_bucket           Destination s3 bucket name

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        s3 Configuration file. Defaults to ~/.s3cfg
  -v, --verbose         Verbose output
  -q, --quiet           No output
  -a, --default-acl     Skip copying ACL from src bucket and use the default
                        ACL of the destination bucket instead
  -e, --encrypt         Use server-side encryption to encrypt the file on S3
  -r, --reduced-redundancy
                        Store objects in the dest bucket using the reduced
                        redundancy storage class
