### PR TITLE
Added argument for number of worker threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ sudo easy_install boto
 pip install -U boto
 ```
 
+When dealing with a very large number of files, you might want to try to use more worker threads:
+
+```
+s3_bucket_to_bucket_copy.py <source_bucket_name>[/<prefix>] <dest_bucket_name> -t 100
+```
 
 Developed by us guys at [Showcase Workshop](http://www.showcaseworkshop.com).
 

--- a/s3_bucket_to_bucket_copy.py
+++ b/s3_bucket_to_bucket_copy.py
@@ -115,7 +115,7 @@ def copy_bucket(aws_key, aws_secret_key, args):
     result_marker = ''
     q = LifoQueue(maxsize=5000)
 
-    for i in range(20):
+    for i in xrange(args.threads_no):
         if args.verbose:
             print 'Adding worker thread %s for queue processing' % i
         t = Worker(q, i, aws_key, aws_secret_key,
@@ -198,7 +198,13 @@ if __name__ == "__main__":
                         dest='rr',
                         required = False,
                         action = 'store_true',
-                        default = False)
+                        default = False),
+    parser.add_argument('-t', '--thread-count',
+                        help='Number of worker threads processing the objects',
+                        dest='threads_no',
+                        required = False,
+                        type = int,
+                        default = 20)
     parser.add_argument('src_bucket', 
                         help = "Source s3 bucket name and optional path")
     parser.add_argument('dest_bucket',


### PR DESCRIPTION
It's useful, when dealing with copying tens or even hundreds of thousands of s3 keys from one place to another, to be able to easily ramp up the number of threads used.
Since their task is network bound*, not CPU bound, it'll likely have a positive impact.


*and bound by the capability of the S3 service